### PR TITLE
fix: 修复在Migrate中,且db.DryRun=true时,GetColumnComment方法因获取不到当前库名而报错

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -234,9 +234,11 @@ func (m Migrator) GetColumnComment(stmt *gorm.Statement, fieldDBName string) (de
 	if m.DB.DryRun {
 		queryTx.DryRun = false
 	}
+	var currentDatabase string
+	_ = queryTx.Raw("SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA');").Row().Scan(&currentDatabase)
 	var comment sql.NullString
 	queryTx.Raw("SELECT COMMENTS FROM ALL_COL_COMMENTS WHERE SCHEMA_NAME = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?",
-		m.CurrentDatabase(), stmt.Table, fieldDBName).Scan(&comment)
+		currentDatabase, stmt.Table, fieldDBName).Scan(&comment)
 	if comment.Valid {
 		description = comment.String
 	}


### PR DESCRIPTION
### Bug场景与原因

有表改动(例如string型字段长度变化)时, 需要执行`db.AutoMigrate(...)`.
在交互式的命令行程序中，一般设置`db.DryRun = true`并执行`db.AutoMigrate(...)`, 先打印出SQL语句, 人为确认没啥问题后, 重设`db.DryRun = false`再次执行`db.AutoMigrate(...)`.

本库中的`Migrator.CurrentDatabase()`方法在`db.DryRun = true`时, 因不实际执行查询逻辑而报错并奔溃, 日志如下：
```log
2025-02-08T18:25:35+08:00       ERROR   dry run mode unsupported
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0xdafe29]

goroutine 1 [running]:
database/sql.(*Row).Scan(0xc0000a8c00?, {0xc00083b448?, 0x30?, 0x0?})
        D:/Go/src/database/sql/sql.go:3443 +0x29
github.com/godoes/gorm-dameng.Migrator.CurrentDatabase({{{0x1, 0xc0000a8a50, {0x2143070, 0xc000793040}}}, {0xc000793040}})
        F:/goproject/gorm-dameng/migrator.go:64 +0x93
github.com/godoes/gorm-dameng.Migrator.GetColumnComment({{{0x1, 0xc0000a8a50, {0x2143070, 0xc000793040}}}, {0xc000793040}}, 0xc000685180, {0xc00078dff8, 0x2})
        F:/goproject/gorm-dameng/migrator.go:242 +0x119
github.com/godoes/gorm-dameng.Migrator.MigrateColumn.func1(0xc000685180)
        F:/goproject/gorm-dameng/migrator.go:380 +0x4d
gorm.io/gorm/migrator.Migrator.RunWithValue({{0xa8?, 0xc0000a8a50?, {0x2143070?, 0xc000793040?}}}, {0x1ac1460, 0xc0007b6900}, 0xc00083b6e0)
        F:/gopath/pkg/mod/gorm.io/gorm@v1.25.12/migrator/migrator.go:74 +0x12b
github.com/godoes/gorm-dameng.Migrator.MigrateColumn({{{0x1, 0xc0000a8a50, {0x2143070, 0xc000793040}}}, {0xc000793040}}, {0x1ac1460, 0xc0007b6900}, 0xc00080c600, {0x2148878, 0xc0000d4410})
        F:/goproject/gorm-dameng/migrator.go:379 +0xb0f
gorm.io/gorm/migrator.Migrator.AutoMigrate.func1(0xc0006841c0)
        F:/gopath/pkg/mod/gorm.io/gorm@v1.25.12/migrator/migrator.go:161 +0x265
gorm.io/gorm/migrator.Migrator.RunWithValue({{0xa0?, 0xc0007ed170?, {0x2143070?, 0xc000793040?}}}, {0x1ac1460, 0xc0007b6900}, 0xc00083bb28)
        F:/gopath/pkg/mod/gorm.io/gorm@v1.25.12/migrator/migrator.go:74 +0x12b
gorm.io/gorm/migrator.Migrator.AutoMigrate({{0x0?, 0xc0007ed170?, {0x2143070?, 0xc000793040?}}}, {0xc0007faf20?, 0xc000055c28?, 0x7c1e7b?})
        F:/gopath/pkg/mod/gorm.io/gorm@v1.25.12/migrator/migrator.go:129 +0x196
github.com/godoes/gorm-dameng.Migrator.AutoMigrate({{{0x1, 0xc0007ed170, {0x2143070, 0xc000793040}}}, {0xc000793040}}, {0xc0007faf20, 0x1, 0x0?})
        F:/goproject/gorm-dameng/migrator.go:33 +0x7a
gorm.io/gorm.(*DB).AutoMigrate(0x7f9a0b?, {0xc0007faf20, 0x1, 0x1})
        F:/gopath/pkg/mod/gorm.io/gorm@v1.25.12/migrator.go:24 +0x42
```

一般情况下gorm官方对`DryRun`有相应的处理逻辑：
```golang
// go-gorm: /migrator/migrator.go 第123行
func (m Migrator) GetQueryAndExecTx() (queryTx, execTx *gorm.DB) {
	queryTx = m.DB.Session(&gorm.Session{})
	execTx = queryTx
	if m.DB.DryRun {
		queryTx.DryRun = false
		execTx = m.DB.Session(&gorm.Session{Logger: &printSQLLogger{Interface: m.DB.Logger}})
	}
	return queryTx, execTx
}

// AutoMigrate auto migrate values
func (m Migrator) AutoMigrate(values ...interface{}) error {
	for _, value := range m.ReorderModels(values, true) {
		queryTx, execTx := m.GetQueryAndExecTx()
		... ...
```
分场景使用 db session: `queryTx`与`execTx`, 在执行信息查询时使用`queryTx`, 在执行表结构调整时使用`execTx`.
本库的`Migrator.MigrateColumn()`方法中, 使用默认session:`execTx` 间接调用`Migrator.CurrentDatabase()`查询当前库名, 因此会报错并奔溃.


### 解决方案

方案一: 在内部方法`Migrator.GetColumnComment()`中不直接调用`Migrator.CurrentDatabase()`, 改成使用`queryTx`直接查询出当前库名.  _详情见本次提交的代码改动_

方案二: 修改`Migrator.CurrentDatabase()`方法, 创建并使用`queryTx`来查询当前库名. 如下所示：
```golang
func (m Migrator) CurrentDatabase() (name string) {
	queryTx := m.DB.Session(&gorm.Session{Logger: m.DB.Logger.LogMode(logger.Warn)})
	if m.DB.DryRun {
		queryTx.DryRun = false
	}
	_ = queryTx.Raw("SELECT SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA');").Row().Scan(&name)
	return
}
```
