### PR TITLE
refactor: use net.JoinHostPort replace fmt.Sprintf

### DIFF
--- a/dameng.go
+++ b/dameng.go
@@ -1,8 +1,9 @@
 package dameng
 
 import (
-	"fmt"
+	"net"
 	"net/url"
+	"strconv"
 )
 
 // DriverName 数据库驱动、连接字符串协议名称
@@ -24,7 +25,7 @@ func BuildUrl(user, password, host string, port int, urlOptions ...map[string]st
 	dmUrl := &url.URL{
 		Scheme:   DriverName,
 		User:     url.UserPassword(user, password),
-		Host:     fmt.Sprintf("%s:%d", host, port),
+		Host:     net.JoinHostPort(host, strconv.Itoa(port)),
 		RawQuery: propQuery.Encode(),
 	}
 	return dmUrl.String()


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.
在提交 PR 之前，请确保能够选中这些复选框。

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
对于重大变更，请在开始之前先打开一个问题，以就实施设计/计划达成协议。
-->

- [x] Do only one thing. 只做了一件事。
- [x] Non breaking API changes. 非破坏性 API 变更。
- [x] Tested. 已通过测试。<!-- 请尽量添加对应的单元测试，以便更快验证变更代码的正确性，提高 review 效率。-->

### What did this pull request do? 这个 PR 做了什么？

使用`net.JoinHostPort`替代`fmt.Sprintf`, 以便正确处理所有IP地址格式(`fmt.Sprintf`无法处理`IPv6`地址)

### User Case Description 用例描述
`host`为域名，存在`v4`和`v6`的地址，使用`v6`地址时`url`错误
